### PR TITLE
Remove check for config file in working directory

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -25,7 +25,7 @@ abstract class CommandBase extends Command {
 		$this->intuition = new Intuition( 'mwcli' );
 		$this->intuition->registerDomain( 'mwcli', dirname( __DIR__, 2 ) . '/i18n' );
 
-		$default = $this->getConfigDir() . 'config.yml';
+		$default = $this->getConfigDirDefault() . 'config.yml';
 		$this->addOption( 'config', 'c', InputOption::VALUE_OPTIONAL, $this->msg( 'option-config-desc' ), $default );
 	}
 
@@ -54,16 +54,11 @@ abstract class CommandBase extends Command {
 	}
 
 	/**
-	 * @return string The full filesystem path to the directory containing config.yml, always with a trailing slash.
+	 * Get the default config directory (the root directory of mwcli).
+	 * @return string The full filesystem path, always with a trailing slash.
 	 */
-	protected function getConfigDir(): string {
-		// Use the current working directory for the config file,
-		// but that can fail on some systems so we fall back to the script's directory.
-		$configDir = getcwd();
-		if ( false === $configDir ) {
-			$configDir = dirname( __DIR__, 2 );
-		}
-		return rtrim( $configDir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
+	protected function getConfigDirDefault(): string {
+		return rtrim( dirname( __DIR__, 2 ), DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 	}
 
 	/**

--- a/src/Command/ExportContribsCommand.php
+++ b/src/Command/ExportContribsCommand.php
@@ -19,7 +19,7 @@ class ExportContribsCommand extends CommandBase {
 		$this->addOption( 'wiki', 'w', InputOption::VALUE_REQUIRED, $this->msg( 'option-wiki-desc' ) );
 		$this->addOption( 'user', 'u', InputOption::VALUE_REQUIRED, $this->msg( 'option-user-desc' ) );
 		$this->addOption( 'dest', 'd', InputOption::VALUE_REQUIRED, $this->msg( 'option-dest-desc' ),
-			$this->getConfigDir() . 'contribs' );
+			$this->getConfigDirDefault() . 'contribs' );
 		$this->addOption( 'only-author', 'o', InputOption::VALUE_NONE, $this->msg( 'option-only-author-desc' ) );
 	}
 

--- a/tests/SitesAddCommandTest.php
+++ b/tests/SitesAddCommandTest.php
@@ -7,9 +7,10 @@ class SitesAddCommandTest extends TestCase {
 
 	/**
 	 * @covers \Samwilson\MediaWikiCLI\Command\SitesAddCommand
+	 * @dataProvider provideAddSite
 	 */
-	public function testAddSite(): void {
-		$configFile = __DIR__ . '/config.yml';
+	public function testAddSite( $configFilename ): void {
+		$configFile = __DIR__ . '/' . $configFilename;
 		$process = new Process( [ 'bin/mwcli', 'sites:add', '--config', $configFile, '--url', 'https://en.wikipedia.org/' ] );
 		$process->mustRun();
 		static::assertFileExists( $configFile );
@@ -18,5 +19,12 @@ class SitesAddCommandTest extends TestCase {
 			file_get_contents( $configFile )
 		);
 		unlink( $configFile );
+	}
+
+	public function provideAddSite() {
+		return [
+			[ 'config.yml' ],
+			[ 'foobar.yaml' ]
+		];
 	}
 }


### PR DESCRIPTION
The point of the config file is that it contains configuration for
multiple sites, so there's no need to be able to have a cascade of
multiple config files. So, we remove that option now, and only
use config.yml in the mwcli directory.